### PR TITLE
Update get-value dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "get-value": "^1.1.5",
+    "get-value": "^2.0.5",
     "kind-of": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
v1.3.1 of get-value does some weird stuff with require that freaks webpack right out, so I upgraded the dependency. All tests pass, so hopefully this is okay.
