### PR TITLE
Function in "sort with a function" test should be a comparator

### DIFF
--- a/test.js
+++ b/test.js
@@ -120,7 +120,7 @@ describe('arraySort', function() {
     var arr = [{key: 'y'}, {key: 'z'}, {key: 'x'}];
 
     var actual = arraySort(arr, function(a, b) {
-      return a.key > b.key;
+      return a.key < b.key ? -1 : (a.key > b.key ? 1 : 0);
     });
 
     actual.should.eql([


### PR DESCRIPTION
The function used in "should sort with a function" is not a comparator. Not that a function passed to `Array.sort` should follow some rule that the previous function was violating. It is just a coincidence that the test was passing.