### PR TITLE
Support null and undefined values

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+var defaultCompare = require('default-compare');
 var typeOf = require('kind-of');
 var get = require('get-value');
 
@@ -87,27 +88,6 @@ function compare(prop, a, b) {
     return compare(null, get(a, prop), get(b, prop));
   }
   return defaultCompare(a, b);
-}
-
-/**
- * Default compare function used as a fallback
- * for sorting. Built-in array sorting pushes
- * null and undefined values to the end of the array.
- */
-
-function defaultCompare(a, b) {
-  var typeA = typeOf(a);
-  var typeB = typeOf(b);
-
-  if (typeA === 'null') {
-    return typeB === 'null' ? 0 : (typeB === 'undefined' ? -1 : 1);
-  } else if (typeA === 'undefined') {
-    return typeB === 'null' ? 1 : (typeB === 'undefined' ? 0 : 1);
-  } else if (typeB === 'null' || typeB === 'undefined') {
-    return -1;
-  } else {
-    return a < b ? -1 : (a > b ? 1 : 0);
-  }
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -91,11 +91,23 @@ function compare(prop, a, b) {
 
 /**
  * Default compare function used as a fallback
- * for sorting.
+ * for sorting. Built-in array sorting pushes
+ * null and undefined values to the end of the array.
  */
 
 function defaultCompare(a, b) {
-  return a < b ? -1 : (a > b ? 1 : 0);
+  var typeA = typeOf(a);
+  var typeB = typeOf(b);
+
+  if (typeA === 'null') {
+    return typeB === 'null' ? 0 : (typeB === 'undefined' ? -1 : 1);
+  } else if (typeA === 'undefined') {
+    return typeB === 'null' ? 1 : (typeB === 'undefined' ? 0 : 1);
+  } else if (typeB === 'null' || typeB === 'undefined') {
+    return -1;
+  } else {
+    return a < b ? -1 : (a > b ? 1 : 0);
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "default-compare": "^1.0.0",
-    "get-value": "^2.0.5",
-    "kind-of": "^2.0.0"
+    "get-value": "^2.0.6",
+    "kind-of": "^5.0.2"
   },
   "devDependencies": {
     "ansi-bold": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "default-compare": "^1.0.0",
     "get-value": "^2.0.5",
     "kind-of": "^2.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -60,6 +60,34 @@ describe('arraySort', function() {
     ]);
   });
 
+  it('should sort by a property with null values:', function() {
+    var arr = [{key: null}, {key: 'z'}, {key: 'x'}];
+    arraySort(arr, 'key').should.eql([
+      {key: 'x'},
+      {key: 'z'},
+      {key: null}
+    ]);
+  });
+
+  it('should sort by a property with undefined values:', function() {
+    var arr = [{}, {key: 'z'}, {key: 'x'}];
+    arraySort(arr, 'key').should.eql([
+      {key: 'x'},
+      {key: 'z'},
+      {}
+    ]);
+  });
+
+  it('should sort by a property with null and undefined values:', function() {
+    var arr = [{key: null}, {key: 'z'}, {}, {key: 'x'}];
+    arraySort(arr, 'key').should.eql([
+      {key: 'x'},
+      {key: 'z'},
+      {key: null},
+      {}
+    ]);
+  });
+
   it('should sort by a nested property:', function() {
     var res = arraySort(posts, 'locals.date');
     res.should.eql([
@@ -113,6 +141,84 @@ describe('arraySort', function() {
       { foo: 'ccc', locals: { date: '2015-01-02' } },
       { foo: 'ddd', locals: { date: '2014-01-09' } },
       { foo: 'ddd', locals: { date: '2015-04-12' } }
+    ]);
+  });
+
+  it('should sort by multiple properties with null values:', function() {
+    var posts = [
+      { foo: 'bbb', locals: { date: '2013-05-06' } },
+      { foo: 'aaa', locals: { date: '2012-01-02' } },
+      { foo: null, locals: { date: '2015-04-12' } },
+      { foo: 'ccc', locals: { date: '2014-01-02' } },
+      { foo: null, locals: { date: '2015-01-02' } },
+      { foo: 'ddd', locals: { date: '2014-01-09' } },
+      { foo: 'bbb', locals: { date: null } },
+      { foo: 'aaa', locals: { date: '2014-02-02' } },
+    ];
+
+    var actual = arraySort(posts, ['foo', 'locals.date']);
+
+    actual.should.eql([
+      { foo: 'aaa', locals: { date: '2012-01-02' } },
+      { foo: 'aaa', locals: { date: '2014-02-02' } },
+      { foo: 'bbb', locals: { date: '2013-05-06' } },
+      { foo: 'bbb', locals: { date: null } },
+      { foo: 'ccc', locals: { date: '2014-01-02' } },
+      { foo: 'ddd', locals: { date: '2014-01-09' } },
+      { foo: null, locals: { date: '2015-01-02' } },
+      { foo: null, locals: { date: '2015-04-12' } }
+    ]);
+  });
+
+  it('should sort by multiple properties with undefined values:', function() {
+    var posts = [
+      { foo: 'bbb', locals: { date: '2013-05-06' } },
+      { foo: 'aaa', locals: { date: '2012-01-02' } },
+      { locals: { date: '2015-04-12' } },
+      { foo: 'ccc', locals: { date: '2014-01-02' } },
+      { locals: { date: '2015-01-02' } },
+      { foo: 'ddd', locals: { date: '2014-01-09' } },
+      { foo: 'bbb', locals: {} },
+      { foo: 'aaa', locals: { date: '2014-02-02' } },
+    ];
+
+    var actual = arraySort(posts, ['foo', 'locals.date']);
+
+    actual.should.eql([
+      { foo: 'aaa', locals: { date: '2012-01-02' } },
+      { foo: 'aaa', locals: { date: '2014-02-02' } },
+      { foo: 'bbb', locals: { date: '2013-05-06' } },
+      { foo: 'bbb', locals: {} },
+      { foo: 'ccc', locals: { date: '2014-01-02' } },
+      { foo: 'ddd', locals: { date: '2014-01-09' } },
+      { locals: { date: '2015-01-02' } },
+      { locals: { date: '2015-04-12' } }
+    ]);
+  });
+
+  it('should sort by multiple properties with null and undefined values:', function() {
+    var posts = [
+      { foo: 'bbb', locals: { date: '2013-05-06' } },
+      { foo: 'aaa', locals: { date: null } },
+      { locals: { date: '2015-04-12' } },
+      { foo: 'ccc', locals: { date: '2014-01-02' } },
+      { locals: { date: '2015-01-02' } },
+      { foo: 'ddd', locals: { date: '2014-01-09' } },
+      { foo: null, locals: {} },
+      { foo: 'aaa', locals: { date: '2014-02-02' } },
+    ];
+
+    var actual = arraySort(posts, ['foo', 'locals.date']);
+
+    actual.should.eql([
+      { foo: 'aaa', locals: { date: '2014-02-02' } },
+      { foo: 'aaa', locals: { date: null } },
+      { foo: 'bbb', locals: { date: '2013-05-06' } },
+      { foo: 'ccc', locals: { date: '2014-01-02' } },
+      { foo: 'ddd', locals: { date: '2014-01-09' } },
+      { foo: null, locals: {} },
+      { locals: { date: '2015-01-02' } },
+      { locals: { date: '2015-04-12' } }
     ]);
   });
 


### PR DESCRIPTION
This PR fixes #3.

I'm opening the PR to get feedback before publishing. Since the built-in `Array.prototype.sort` function will push `null` and `undefined` values to the end of the array, I implemented this in a similar fashion.

My first thought was that this could be implemented with a custom compare function, but the `get-object` functionality would have to be added to that custom compare function too.
